### PR TITLE
Fp 89 be establish pagination for routes on java be

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,10 +13,46 @@ Labs teams must follow all [Labs Engineering Standards](https://bloomtechlabs.gi
 
 ## Getting Started
 
-### Enviornment Variables
+### Environment Variables
 
 - `awsaccesskey` - key to access aws instance local/deployed
 - `awssecretkey` - authorization token for aws instance (eg. SUPERSECRET)
 - `dynamodburl` - connection string for dynamo
 
 See application-dev.properties for example values
+
+# Pagination
+To add pagination to your service and controller, follow these steps:
+
+## Service Class
+1. Add a method named getAllExamplesPaginated that takes in two arguments: offset and limit.
+2. Implement the logic for fetching a paginated list of Example objects from your data source (e.g. database).
+
+Example:
+```
+  /**
+  * @param offset page index to return results from.
+  * @param limit number of results to include per page.
+  * @return returns a paginated list of Example objects.
+  */
+  public Page<Example> getAllExamplesPaginated(int offset, int limit) {
+  return exampleRepository.findAll(PageRequest.of(offset, limit));
+  }
+```
+## Controller Class
+1. Add a method named getAllExamplesPaginated that takes in two @PathVariable arguments: offset and limit.
+2. Call the getAllExamplesPaginated method from your service class, passing in the offset and limit arguments.
+3. Return the paginated results as a JSON response to the client.
+
+Example:
+```
+  /**
+  * @param offset page index to return results from.
+  * @param limit number of results to include per page.
+  * @return returns a paginated list of Example objects.
+  */
+  @GetMapping("{offset}/{limit}")
+  public ResponseEntity<Page<Example>> getAllExamplePaginated(@PathVariable int offset, @PathVariable int limit) {
+  return ResponseEntity.ok(exampleService.getAllExamplesPaginated(offset, limit));
+  }
+```

--- a/src/main/java/com/bloomtechlabs/fp/controllers/EducationHistoryController.java
+++ b/src/main/java/com/bloomtechlabs/fp/controllers/EducationHistoryController.java
@@ -1,8 +1,10 @@
 package com.bloomtechlabs.fp.controllers;
 
 import com.bloomtechlabs.fp.entities.EducationHistory;
+import com.bloomtechlabs.fp.entities.EmploymentHistory;
 import com.bloomtechlabs.fp.services.EducationHistoryService;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.domain.Page;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
@@ -19,6 +21,16 @@ public class EducationHistoryController {
     @GetMapping
     List<EducationHistory> getAllEducationHistories() {
         return educationHistoryService.getAllEducationHistories();
+    }
+
+    /**
+     * @param offset page index to return results from.
+     * @param limit number of results to include per page.
+     * @return returns a paginated list.
+     */
+    @GetMapping("{offset}/{limit}")
+    public ResponseEntity<Page<EducationHistory>> getAllEducationHistoriesPaginated(@PathVariable int offset, @PathVariable int limit) {
+        return ResponseEntity.ok(educationHistoryService.getAllEducationHistoriesPaginated(offset, limit));
     }
 
     @PostMapping

--- a/src/main/java/com/bloomtechlabs/fp/controllers/EducationHistoryController.java
+++ b/src/main/java/com/bloomtechlabs/fp/controllers/EducationHistoryController.java
@@ -1,7 +1,6 @@
 package com.bloomtechlabs.fp.controllers;
 
 import com.bloomtechlabs.fp.entities.EducationHistory;
-import com.bloomtechlabs.fp.entities.EmploymentHistory;
 import com.bloomtechlabs.fp.services.EducationHistoryService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.domain.Page;

--- a/src/main/java/com/bloomtechlabs/fp/controllers/EmploymentHistoryController.java
+++ b/src/main/java/com/bloomtechlabs/fp/controllers/EmploymentHistoryController.java
@@ -3,6 +3,7 @@ package com.bloomtechlabs.fp.controllers;
 import com.bloomtechlabs.fp.entities.EmploymentHistory;
 import com.bloomtechlabs.fp.services.EmploymentHistoryService;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.domain.Page;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
@@ -19,6 +20,16 @@ public class EmploymentHistoryController {
     @GetMapping
     List<EmploymentHistory> getAllEmploymentHistories() {
         return employmentHistoryService.getAllEmploymentHistories();
+    }
+
+    /**
+     * @param offset page index to return results from.
+     * @param limit number of results to include per page.
+     * @return returns a paginated list of EmploymentHistory objects.
+     */
+    @GetMapping("{offset}/{limit}")
+    public ResponseEntity<Page<EmploymentHistory>> getAllEmploymentHistoriesPaginated(@PathVariable int offset, @PathVariable int limit) {
+        return ResponseEntity.ok(employmentHistoryService.getAllEmploymentHistoriesPaginated(offset, limit));
     }
 
     @PostMapping

--- a/src/main/java/com/bloomtechlabs/fp/controllers/GoalController.java
+++ b/src/main/java/com/bloomtechlabs/fp/controllers/GoalController.java
@@ -1,6 +1,5 @@
 package com.bloomtechlabs.fp.controllers;
 
-import com.bloomtechlabs.fp.entities.EducationHistory;
 import com.bloomtechlabs.fp.entities.Goal;
 import com.bloomtechlabs.fp.services.GoalService;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -15,7 +14,6 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
-import java.math.BigInteger;
 import java.util.List;
 import java.util.UUID;
 

--- a/src/main/java/com/bloomtechlabs/fp/controllers/GoalController.java
+++ b/src/main/java/com/bloomtechlabs/fp/controllers/GoalController.java
@@ -1,8 +1,10 @@
 package com.bloomtechlabs.fp.controllers;
 
+import com.bloomtechlabs.fp.entities.EducationHistory;
 import com.bloomtechlabs.fp.entities.Goal;
 import com.bloomtechlabs.fp.services.GoalService;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.domain.Page;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -27,6 +29,16 @@ public class GoalController {
     @GetMapping
     public List<Goal> findAllGoals() {
         return goalService.getAllGoals();
+    }
+
+    /**
+     * @param offset page index to return results from.
+     * @param limit number of results to include per page.
+     * @return returns a paginated list.
+     */
+    @GetMapping("{offset}/{limit}")
+    public ResponseEntity<Page<Goal>> findAllGoalsPaginated(@PathVariable int offset, @PathVariable int limit) {
+        return ResponseEntity.ok(goalService.getAllGoalsPaginated(offset, limit));
     }
 
     @GetMapping("{id}")

--- a/src/main/java/com/bloomtechlabs/fp/controllers/HouseholdController.java
+++ b/src/main/java/com/bloomtechlabs/fp/controllers/HouseholdController.java
@@ -1,6 +1,5 @@
 package com.bloomtechlabs.fp.controllers;
 
-import com.bloomtechlabs.fp.entities.EducationHistory;
 import com.bloomtechlabs.fp.entities.Household;
 import com.bloomtechlabs.fp.services.HouseholdService;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -17,7 +16,6 @@ import org.springframework.web.bind.annotation.RestController;
 
 import java.math.BigInteger;
 import java.util.List;
-import java.util.Optional;
 
 @RestController
 @RequestMapping("/households")

--- a/src/main/java/com/bloomtechlabs/fp/controllers/HouseholdController.java
+++ b/src/main/java/com/bloomtechlabs/fp/controllers/HouseholdController.java
@@ -1,8 +1,10 @@
 package com.bloomtechlabs.fp.controllers;
 
+import com.bloomtechlabs.fp.entities.EducationHistory;
 import com.bloomtechlabs.fp.entities.Household;
 import com.bloomtechlabs.fp.services.HouseholdService;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.domain.Page;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -27,6 +29,16 @@ public class HouseholdController {
     @GetMapping
     public List<Household> findAllHouseholds() {
         return householdService.findAllHouseholds();
+    }
+
+    /**
+     * @param offset page index to return results from.
+     * @param limit number of results to include per page.
+     * @return returns a paginated list.
+     */
+    @GetMapping("{offset}/{limit}")
+    public ResponseEntity<Page<Household>> findAllHouseholdsPaginated(@PathVariable int offset, @PathVariable int limit) {
+        return ResponseEntity.ok(householdService.findAllHouseholdsPaginated(offset, limit));
     }
 
     @GetMapping("{id}")

--- a/src/main/java/com/bloomtechlabs/fp/dataseeders/EmploymentHistoryDataSeeder.java
+++ b/src/main/java/com/bloomtechlabs/fp/dataseeders/EmploymentHistoryDataSeeder.java
@@ -27,7 +27,7 @@ public class EmploymentHistoryDataSeeder implements CommandLineRunner {
                         String.format("Certification #%d", i));
                 employmentHistoryService.createEmploymentHistory(tempEmploymentHistory);
             }
-            
+
             UUID uuid1 = UUID.randomUUID();
             EmploymentHistory employmentHistory1 =
                     new EmploymentHistory(uuid1, true, "Forklift Certified");

--- a/src/main/java/com/bloomtechlabs/fp/dataseeders/EmploymentHistoryDataSeeder.java
+++ b/src/main/java/com/bloomtechlabs/fp/dataseeders/EmploymentHistoryDataSeeder.java
@@ -20,6 +20,14 @@ public class EmploymentHistoryDataSeeder implements CommandLineRunner {
 
     private void loadEmploymentHistoryData() {
         if(employmentHistoryService.count() == 0) {
+            for(int i = 1; i <= 200; i++) {
+                EmploymentHistory tempEmploymentHistory = new EmploymentHistory(
+                        UUID.fromString(String.format("00000000-0000-0000-0000-%s", i)),
+                        i % 2 == 0,
+                        String.format("Certification #%d", i));
+                employmentHistoryService.createEmploymentHistory(tempEmploymentHistory);
+            }
+            
             UUID uuid1 = UUID.randomUUID();
             EmploymentHistory employmentHistory1 =
                     new EmploymentHistory(uuid1, true, "Forklift Certified");

--- a/src/main/java/com/bloomtechlabs/fp/services/EducationHistoryService.java
+++ b/src/main/java/com/bloomtechlabs/fp/services/EducationHistoryService.java
@@ -1,9 +1,12 @@
 package com.bloomtechlabs.fp.services;
 
 import com.bloomtechlabs.fp.entities.EducationHistory;
+import com.bloomtechlabs.fp.entities.EmploymentHistory;
 import com.bloomtechlabs.fp.exceptions.ResourceNotFoundException;
 import com.bloomtechlabs.fp.repositories.EducationHistoryRepository;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
 
@@ -17,6 +20,15 @@ public class EducationHistoryService {
 
     public List<EducationHistory> getAllEducationHistories() {
         return educationHistoryRepository.findAll();
+    }
+
+    /**
+     * @param offset page index to return results from.
+     * @param limit number of results to include per page.
+     * @return returns a paginated list.
+     */
+    public Page<EducationHistory> getAllEducationHistoriesPaginated(int offset, int limit) {
+        return educationHistoryRepository.findAll(PageRequest.of(offset, limit));
     }
 
     public EducationHistory createEducationHistory(EducationHistory educationHistory) {

--- a/src/main/java/com/bloomtechlabs/fp/services/EducationHistoryService.java
+++ b/src/main/java/com/bloomtechlabs/fp/services/EducationHistoryService.java
@@ -1,7 +1,6 @@
 package com.bloomtechlabs.fp.services;
 
 import com.bloomtechlabs.fp.entities.EducationHistory;
-import com.bloomtechlabs.fp.entities.EmploymentHistory;
 import com.bloomtechlabs.fp.exceptions.ResourceNotFoundException;
 import com.bloomtechlabs.fp.repositories.EducationHistoryRepository;
 import org.springframework.beans.factory.annotation.Autowired;

--- a/src/main/java/com/bloomtechlabs/fp/services/EmploymentHistoryService.java
+++ b/src/main/java/com/bloomtechlabs/fp/services/EmploymentHistoryService.java
@@ -5,6 +5,8 @@ import com.bloomtechlabs.fp.entities.EmploymentHistory;
 import com.bloomtechlabs.fp.exceptions.ResourceNotFoundException;
 import com.bloomtechlabs.fp.repositories.EmploymentHistoryRepository;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
 
@@ -18,6 +20,15 @@ public class EmploymentHistoryService {
 
     public List<EmploymentHistory> getAllEmploymentHistories() {
         return employmentHistoryRepository.findAll();
+    }
+
+    /**
+     * @param offset page index to return results from.
+     * @param limit number of results to include per page.
+     * @return returns a paginated list of EmploymentHistory objects.
+     */
+    public Page<EmploymentHistory> getAllEmploymentHistoriesPaginated(int offset, int limit) {
+        return employmentHistoryRepository.findAll(PageRequest.of(offset, limit));
     }
 
     public EmploymentHistory createEmploymentHistory(EmploymentHistory employmentHistory) {

--- a/src/main/java/com/bloomtechlabs/fp/services/EmploymentHistoryService.java
+++ b/src/main/java/com/bloomtechlabs/fp/services/EmploymentHistoryService.java
@@ -1,6 +1,5 @@
 package com.bloomtechlabs.fp.services;
 
-
 import com.bloomtechlabs.fp.entities.EmploymentHistory;
 import com.bloomtechlabs.fp.exceptions.ResourceNotFoundException;
 import com.bloomtechlabs.fp.repositories.EmploymentHistoryRepository;

--- a/src/main/java/com/bloomtechlabs/fp/services/GoalService.java
+++ b/src/main/java/com/bloomtechlabs/fp/services/GoalService.java
@@ -1,9 +1,12 @@
 package com.bloomtechlabs.fp.services;
 
+import com.bloomtechlabs.fp.entities.EducationHistory;
 import com.bloomtechlabs.fp.entities.Goal;
 import com.bloomtechlabs.fp.exceptions.ResourceNotFoundException;
 import com.bloomtechlabs.fp.repositories.GoalRepository;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
 
@@ -18,6 +21,15 @@ public class GoalService {
 
     public List<Goal> getAllGoals() {
         return goalRepository.findAll();
+    }
+
+    /**
+     * @param offset page index to return results from.
+     * @param limit number of results to include per page.
+     * @return returns a paginated list.
+     */
+    public Page<Goal> getAllGoalsPaginated(int offset, int limit) {
+        return goalRepository.findAll(PageRequest.of(offset, limit));
     }
 
     public Goal createGoal(Goal goal) {

--- a/src/main/java/com/bloomtechlabs/fp/services/GoalService.java
+++ b/src/main/java/com/bloomtechlabs/fp/services/GoalService.java
@@ -1,6 +1,5 @@
 package com.bloomtechlabs.fp.services;
 
-import com.bloomtechlabs.fp.entities.EducationHistory;
 import com.bloomtechlabs.fp.entities.Goal;
 import com.bloomtechlabs.fp.exceptions.ResourceNotFoundException;
 import com.bloomtechlabs.fp.repositories.GoalRepository;

--- a/src/main/java/com/bloomtechlabs/fp/services/HouseholdService.java
+++ b/src/main/java/com/bloomtechlabs/fp/services/HouseholdService.java
@@ -1,9 +1,12 @@
 package com.bloomtechlabs.fp.services;
 
+import com.bloomtechlabs.fp.entities.EducationHistory;
 import com.bloomtechlabs.fp.entities.Household;
 import com.bloomtechlabs.fp.exceptions.ResourceNotFoundException;
 import com.bloomtechlabs.fp.repositories.HouseholdRepository;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
 
@@ -19,6 +22,15 @@ public class HouseholdService {
 
     public List<Household> findAllHouseholds() {
         return householdRepository.findAll();
+    }
+
+    /**
+     * @param offset page index to return results from.
+     * @param limit number of results to include per page.
+     * @return returns a paginated list.
+     */
+    public Page<Household> findAllHouseholdsPaginated(int offset, int limit) {
+        return householdRepository.findAll(PageRequest.of(offset, limit));
     }
 
     public ResponseEntity<Household> getHouseholdById(BigInteger id) {

--- a/src/main/java/com/bloomtechlabs/fp/services/HouseholdService.java
+++ b/src/main/java/com/bloomtechlabs/fp/services/HouseholdService.java
@@ -1,6 +1,5 @@
 package com.bloomtechlabs.fp.services;
 
-import com.bloomtechlabs.fp.entities.EducationHistory;
 import com.bloomtechlabs.fp.entities.Household;
 import com.bloomtechlabs.fp.exceptions.ResourceNotFoundException;
 import com.bloomtechlabs.fp.repositories.HouseholdRepository;


### PR DESCRIPTION
Created pagination handling for existing backend routes was accomplished, including a README explanation for future developers to implement pagination, and the ability to handle the number of results per page requested by the client.

[Loom review video](https://www.loom.com/share/cf4d1e23dc814456b5a3731f65fed877)