### PR TITLE
FP-93-BD-Implement-Caching-for-Intake-Data-Storage

### DIFF
--- a/.env
+++ b/.env
@@ -1,7 +1,0 @@
-PORT=8000
-DS_API_URL=http://localhost:8002
-DS_API_TOKEN=SUPERSECRET
-DATABASE_URL=postgres://docker:docker@127.0.0.1:5400/api-dev
-AUTH0_DOMAIN=https://dev-35n2stap.auth0.com
-AUTH0_CLIENT_ID=YMKcoQEU2VeWgKlvfImLU2M0mjXn3gvc
-AUTH0_AUDIENCE=https://family-promise-case-mgmt.herokuapp.com/

--- a/.env
+++ b/.env
@@ -1,0 +1,7 @@
+PORT=8000
+DS_API_URL=http://localhost:8002
+DS_API_TOKEN=SUPERSECRET
+DATABASE_URL=postgres://docker:docker@127.0.0.1:5400/api-dev
+AUTH0_DOMAIN=https://dev-35n2stap.auth0.com
+AUTH0_CLIENT_ID=YMKcoQEU2VeWgKlvfImLU2M0mjXn3gvc
+AUTH0_AUDIENCE=https://family-promise-case-mgmt.herokuapp.com/

--- a/build.gradle
+++ b/build.gradle
@@ -29,6 +29,8 @@ repositories {
 dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
+	implementation 'com.github.jedis-lock:jedis-lock:1.0.0'
+	implementation 'redis.clients:jedis:4.3.1'
 	compileOnly 'org.projectlombok:lombok'
 	runtimeOnly 'org.postgresql:postgresql'
 	annotationProcessor 'org.projectlombok:lombok'
@@ -37,6 +39,12 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-thymeleaf'
 	implementation 'org.thymeleaf.extras:thymeleaf-extras-springsecurity5'
 	implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'
+	// added for Redis (caching):
+// https://mvnrepository.com/artifact/org.springframework.boot/spring-boot-starter-data-redis
+	implementation 'org.springframework.boot:spring-boot-starter-data-redis:2.7.9'
+
+
+
 }
 
 tasks.named('test') {

--- a/src/main/java/com/bloomtechlabs/fp/redis/RedisConfig.java
+++ b/src/main/java/com/bloomtechlabs/fp/redis/RedisConfig.java
@@ -1,0 +1,2 @@
+package com.bloomtechlabs.fp.redis;public class RedisConfig {
+}

--- a/src/main/java/com/bloomtechlabs/fp/redis/RedisConfig.java
+++ b/src/main/java/com/bloomtechlabs/fp/redis/RedisConfig.java
@@ -1,2 +1,92 @@
-package com.bloomtechlabs.fp.redis;public class RedisConfig {
+package com.bloomtechlabs.fp.redis;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.autoconfigure.AutoConfigureAfter;
+import org.springframework.boot.autoconfigure.data.redis.RedisAutoConfiguration;
+import org.springframework.cache.CacheManager;
+import org.springframework.cache.annotation.EnableCaching;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.cache.RedisCacheConfiguration;
+import org.springframework.data.redis.cache.RedisCacheManager;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSerializer;
+import org.springframework.data.redis.serializer.RedisSerializationContext;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
+
+import java.io.Serializable;
+
+
+/*
+------- DOCUMENTATION -------
+The RedisConfig class is a Spring configuration class that provides configuration for Redis caching.
+It uses Spring's @Configuration annotation to indicate that it is a configuration class and @EnableCaching to enable caching for the application.
+
+The @AutoConfigureAfter annotation is used to specify that the Redis configuration should be done after the RedisAutoConfiguration class is configured.
+This ensures that the Redis configuration is done after Redis is initialized.
+
+The RedisConfig class has two methods: redisCacheTemplate() and cacheManager().
+The first method creates a RedisTemplate for caching and the second method creates a CacheManager for caching.
+
+Configuration Properties:
+The Redis host and port are read from the Spring configuration properties using the @Value annotation.
+These properties are injected into the RedisConfig class and used to configure the Redis connection factory.
+
+By A.M., Feb 25 2023
+ */
+@Configuration
+@AutoConfigureAfter(RedisAutoConfiguration.class)
+@EnableCaching
+public class RedisConfig {
+
+    @Autowired
+    private CacheManager cacheManager;
+
+    @Value("${spring.redis.host}")
+    private String redisHost;
+
+    @Value("${spring.redis.port}")
+    private int redisPort;
+
+    /*
+    Redis Cache Template
+    The redisCacheTemplate() method creates a RedisTemplate bean with a LettuceConnectionFactory.
+    The RedisTemplate is a generic class that takes two parameters: the key and value types. In this case, the key type is String and the value type is Serializable.
+    The template.setKeySerializer(new StringRedisSerializer()) line sets the key serializer to the StringRedisSerializer, which serializes the keys as strings.
+    The template.setValueSerializer(new GenericJackson2JsonRedisSerializer()) line sets the value serializer to the GenericJackson2JsonRedisSerializer,
+    which serializes the values using Jackson's JSON serializer.
+     */
+
+    @Bean
+    public RedisTemplate<String, Serializable> redisCacheTemplate(LettuceConnectionFactory redisConnectionFactory) {
+        RedisTemplate<String, Serializable> template = new RedisTemplate<>();
+        template.setKeySerializer(new StringRedisSerializer());
+        template.setValueSerializer(new GenericJackson2JsonRedisSerializer());
+        template.setConnectionFactory(redisConnectionFactory);
+        return template;
+    }
+
+    /*
+    Cache Manager
+    The cacheManager() method creates a CacheManager bean with a RedisConnectionFactory.
+    The RedisCacheConfiguration is used to configure the caching behavior, and RedisCacheManager is used to manage the cache..
+     */
+
+    @Bean
+    public CacheManager cacheManager(RedisConnectionFactory factory) {
+        RedisCacheConfiguration config = RedisCacheConfiguration.defaultCacheConfig();
+        RedisCacheConfiguration redisCacheConfiguration = config
+                .serializeKeysWith(
+                        RedisSerializationContext.SerializationPair.fromSerializer(new StringRedisSerializer()))
+                .serializeValuesWith(RedisSerializationContext.SerializationPair
+                        .fromSerializer(new GenericJackson2JsonRedisSerializer()));
+        RedisCacheManager redisCacheManager = RedisCacheManager.builder(factory).cacheDefaults(redisCacheConfiguration)
+                .build();
+        return redisCacheManager;
+    }
+
 }
+

--- a/src/main/java/com/bloomtechlabs/fp/services/impl/EducationHistoryImplementation.java
+++ b/src/main/java/com/bloomtechlabs/fp/services/impl/EducationHistoryImplementation.java
@@ -1,0 +1,2 @@
+package com.bloomtechlabs.fp.services.impl;public class EducationHistoryImplementation {
+}

--- a/src/main/java/com/bloomtechlabs/fp/services/impl/EducationHistoryImplementation.java
+++ b/src/main/java/com/bloomtechlabs/fp/services/impl/EducationHistoryImplementation.java
@@ -1,2 +1,106 @@
-package com.bloomtechlabs.fp.services.impl;public class EducationHistoryImplementation {
+package com.bloomtechlabs.fp.services.impl;
+import com.bloomtechlabs.fp.entities.EducationHistory;
+import com.bloomtechlabs.fp.repositories.EducationHistoryRepository;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.cache.annotation.CacheConfig;
+import org.springframework.cache.annotation.CacheEvict;
+import org.springframework.cache.annotation.Cacheable;
+import org.springframework.cache.annotation.Caching;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.Optional;
+
+
+/*
+------- DOCUMENTATION -------
+
+This is a Spring @Service implementation class called EducationHistoryImplementation.
+It provides an implementation of the EducationHistoryService, which is a service layer class for managing education history data.
+Unlike the traditional approach of defining an interface and then providing an implementation of that interface,
+this implementation class directly provides the implementation of the service layer logic without using an interface.
+This implementation class uses Spring's caching functionality to cache frequently accessed data, which can help to improve application performance.
+
+The class is declared with the @Service annotation, which marks it as a Spring-managed service bean.
+It also uses the @CacheConfig annotation to specify the name of the cache to use for caching the EducationHistory objects.
+
+*** METHODS ***
+The class has several methods, each of which is annotated with caching annotations for caching purposes. These methods are:
+* getAll() method: This method returns a list of all EducationHistory objects. It is annotated with the @Cacheable annotation, which indicates that the result of this method should be cached with the specified cache name.
+The method waits for 3 seconds using the waitSomeTime() method, which is for demo purposes to simulate a long-running operation.
+
+* add() method: This method adds a new EducationHistory object to the database.
+It is annotated with the @CacheEvict annotation, which indicates that the cache with the specified name should be evicted after the method call.
+
+* update() method: This method updates an existing EducationHistory object in the database.
+It is annotated with the @CacheEvict annotation, which indicates that the cache with the specified name should be evicted after the method call.
+
+* delete() method: This method deletes an existing EducationHistory object from the database.
+It is annotated with the @Caching annotation, which combines two @CacheEvict annotations. One annotation specifies that the cache with the specified key should be evicted, and the other annotation specifies that the entire cache should be evicted after the method call.
+
+* getCustomerById() method: This method retrieves an EducationHistory object from the database by ID.
+It is annotated with the @Cacheable annotation, which indicates that the result of this method should be cached with the specified cache name and key.
+The unless attribute specifies that the result should not be cached if it is null.
+
+It also has a private method called waitSomeTime(), which is used to simulate a long-running operation.
+
+By A.M., Feb 25 2023
+ */
+
+@Service
+@CacheConfig(cacheNames = "educationHistoryCache")
+
+public class EducationHistoryImplementation  {
+
+    @Autowired
+    private EducationHistoryRepository educationHistoryRepository;
+
+    @Cacheable(cacheNames = "educationHistoryCache")
+    public List<EducationHistory> getAll() {
+        waitSomeTime();
+        return this.educationHistoryRepository.findAll();
+    }
+
+    @CacheEvict(cacheNames = "educationHistoryCache", allEntries = true)
+    public EducationHistory add(EducationHistory educationHistory) {
+        return this.educationHistoryRepository.save(educationHistory);
+    }
+
+    @CacheEvict(cacheNames = "educationHistoryCache", allEntries = true)
+    public EducationHistory update(EducationHistory educationHistory) {
+
+        Optional<EducationHistory> optionalEducationHistory = this.educationHistoryRepository.findById(educationHistory.getId().getMostSignificantBits());
+        // getMostSignificantBits method is to convert UUID to long. If there are issues consider changing return type of method getId from EducationHistory to long
+        if (!optionalEducationHistory.isPresent())
+            return null;
+        EducationHistory repEducationHistory = optionalEducationHistory.get();
+        repEducationHistory.setClientId(educationHistory.getClientId());
+        repEducationHistory.setLevel(educationHistory.getLevel());
+        repEducationHistory.setStartDate(educationHistory.getStartDate());
+        repEducationHistory.setEndDate(educationHistory.getEndDate());
+        repEducationHistory.setSchoolName(educationHistory.getSchoolName());
+        return this.educationHistoryRepository.save(repEducationHistory);
+    }
+
+    @Caching(evict = {@CacheEvict(cacheNames = "educationHistoryCache", key = "#id"),
+            @CacheEvict(cacheNames = "educationHistoryCache", allEntries = true)})
+    public void delete(long id){
+        this.educationHistoryRepository.deleteById(id);
+    }
+
+    @Cacheable(cacheNames = "educationHistoryCache", key = "#id", unless = "#result == null")
+    public EducationHistory getCustomerById (long id) {
+        waitSomeTime();
+        return this.educationHistoryRepository.findById(id).orElse(null);
+    }
+
+    private void waitSomeTime() {
+        System.out.println("Long Wait Begin");
+        try{
+            Thread.sleep(3000);
+        } catch (InterruptedException e) {
+            e.printStackTrace();
+        }
+        System.out.println("Long Wait End");
+    }
 }


### PR DESCRIPTION
I used Redis to set up caching. I created two classes in two new packages, both with thorough documentation. At a glance, 

1. RedisConfig class is a Spring configuration class that provides configuration for Redis caching.
2. EducationHistoryImplementation provides an implementation of the EducationHistoryService, which is a service layer class for managing education history data.

Next steps:
1. Create 3 implementation classes for Employment History, Goal, and Household
2. Add caching to docker-compose.yaml under "services"

Requested feedback:
1. If the two classes are implemented correctly, including whether it is okay to implement those services without an interface (as I did - more in the documentation of EducationHistoryImplementation)